### PR TITLE
Fix strange image path handling

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -75,7 +75,7 @@ $.setBackgroundColor = function(_color) {
 	if(hexToHsb(_color).b < 65) {
 		theme = "white";
 	} else {
-		theme = "black"
+		theme = "black";
 	}
 };
 

--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -16,20 +16,14 @@ var navigation, theme;
 var deviceVersion = parseInt(Titanium.Platform.version.split(".")[0], 10);
 
 if(CONFIG.image) {
-	var image = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, CONFIG.image);
-
-	if(image.exists()) {
-		image = image.nativePath;
-
-		$.title = Ti.UI.createImageView({
-			image: image,
-			height: "26dp",
-			width: Ti.UI.SIZE,
-			top: (OS_IOS && deviceVersion >= 7) ? "30dp" : "10dp",
-			bottom: "10dp",
-			preventDefaultImage: true
-		});
-	}
+	$.title = Ti.UI.createImageView({
+		image: CONFIG.image,
+		height: "26dp",
+		width: Ti.UI.SIZE,
+		top: (OS_IOS && deviceVersion >= 7) ? "30dp" : "10dp",
+		bottom: "10dp",
+		preventDefaultImage: true
+	});
 } else {
 	$.title = Ti.UI.createLabel({
 		top: (OS_IOS && deviceVersion >= 7) ? "20dp" : "0dp",


### PR DESCRIPTION
I'm not sure what the purpose of using the filesystem resource directory is, but I was not able to load any images when it was being used. After removing it I was able to just provide paths like the rest of Alloy, e.g. image: "/images/foo.png".
