### PR TITLE
Prevent title ImageView from blocking clicks on left and right ImageView’s on Android

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -260,7 +260,7 @@ function hexToHsb(_hex) {
 }
 
 if($.title) {
-	$.Wrapper.add($.title);
+	$.titleView.add($.title);
 }
 
 // Move the UI down if iOS7+

--- a/views/widget.xml
+++ b/views/widget.xml
@@ -1,6 +1,8 @@
 <Alloy>
 	<View id="Wrapper">
 		<View id="overlay">
+			<View id="titleView" />
+			
 			<View id="back" visible="false">
 				<ImageView id="backImage" />
 			</View>


### PR DESCRIPTION
When using an image for the title, on Android the left and right views were being blocked from receiving clicks. Adding the title to a subview and not the main wrapper fixes this by displaying left and right on top of the title view.
