### PR TITLE
Remove buggy iOS 7 specific title placement

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -25,14 +25,14 @@ if(CONFIG.image) {
 			image: image,
 			height: "26dp",
 			width: Ti.UI.SIZE,
-			top: (OS_IOS && deviceVersion >= 7) ? "30dp" : "10dp",
+			top: "10dp",
 			bottom: "10dp",
 			preventDefaultImage: true
 		});
 	}
 } else {
 	$.title = Ti.UI.createLabel({
-		top: (OS_IOS && deviceVersion >= 7) ? "20dp" : "0dp",
+		top: "0dp",
 		left: "58dp",
 		right: "58dp",
 		height: "46dp",


### PR DESCRIPTION
I'm not sure of Titanium's handling of positions in iOS 7 has changed but the title displayed properly without the additional top space.
